### PR TITLE
Add React UI and Flask API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python
+__pycache__/
+*.pyc
+
+# Node
+node_modules/
+*.log
+npm-debug.log*
+
+# Env
+.env
+
+# Others
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # project-oop- Retail Management System Phase 1
+
+This project now includes a small Flask API server and a React based user interface.
+
+## Backend
+
+Install Python dependencies and run the server:
+
+```bash
+pip install -r requirements.txt
+python server.py
+```
+
+The server loads the store data from the `Store` directory and exposes two endpoints:
+
+- `GET /api/products` – list all products.
+- `POST /api/login` – login with JSON body `{"user_id": "<id>", "password": "<pass>"}`.
+
+## Frontend
+
+A minimal React application is located in the `frontend` directory. Install Node dependencies and start the development server:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The React app fetches product data from `http://localhost:5000/api/products` and displays it.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "store-ui",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Store UI</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+function App() {
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:5000/api/products')
+      .then((res) => res.json())
+      .then((data) => setProducts(data))
+      .catch(console.error);
+  }, []);
+
+  return (
+    <div>
+      <h1>Store Products</h1>
+      <ul>
+        {products.map((p) => (
+          <li key={p.name}>
+            <strong>{p.name}</strong> - {p.model} - ${'{'}p.price{'}'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+flask-cors

--- a/server.py
+++ b/server.py
@@ -1,0 +1,41 @@
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+from Store.store import Store
+from Store.storeerror import StoreError
+
+app = Flask(__name__)
+CORS(app)
+
+store = Store()
+try:
+    store.load_files()
+except Exception:
+    pass
+
+@app.route('/api/products')
+def get_products():
+    products = []
+    for prod in store.collection.values():
+        products.append({
+            'name': prod.name,
+            'model': prod.model,
+            'description': prod.description,
+            'price': prod.price,
+            'quantity': prod.quantity
+        })
+    return jsonify(products)
+
+@app.route('/api/login', methods=['POST'])
+def login():
+    data = request.get_json(force=True)
+    user_id = data.get('user_id')
+    password = data.get('password')
+    try:
+        user = store.log(user_id, password)
+        return jsonify({'message': 'success', 'user_type': user.__class__.__name__})
+    except StoreError.AuthenticationError as e:
+        return jsonify({'error': str(e)}), 400
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add minimal Flask server exposing login and product endpoints
- add React interface in `frontend`
- include package requirements and update instructions

## Testing
- `pytest -q`
- `npm install --ignore-scripts` *(fails: 9 vulnerabilities)*

------
https://chatgpt.com/codex/tasks/task_e_684d692e3bb08331a2b316fab60910fc